### PR TITLE
Task 5. Resolve an issue with Reserved Names

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -2224,6 +2224,12 @@ reservedKeywords returns [String name]
 	"map" { name = "map"; }
 	|
 	"array" { name = "array"; }
+	|
+	"copy-namespaces" { name = "copy-namespaces"; }
+	|
+    "empty-sequence" { name = "empty-sequence"; }
+    |
+    "schema-element" { name = "schema-element"; }
 	;
 
 /**

--- a/exist-core/src/test/java/org/exist/xquery/ReservedNamesConflictTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ReservedNamesConflictTest.java
@@ -1,0 +1,65 @@
+package org.exist.xquery;
+
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
+import antlr.collections.AST;
+import org.exist.EXistException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.parser.*;
+import org.junit.ClassRule;
+import org.junit.Test;
+import java.io.StringReader;
+import static org.junit.Assert.*;
+
+public class ReservedNamesConflictTest
+{
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void reservedNamesIssueTest() throws EXistException, RecognitionException, XPathException, TokenStreamException
+    {
+        String query =  "xquery version \"3.1\";\n" +
+                "<foo copy-namespaces=\"bar\"/>,\n" +
+                "<foo empty-sequence=\"bar\"/>,\n" +
+                "<foo schema-element=\"bar\"/>";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+
+           XQueryAST one = (XQueryAST) ast.getNextSibling().getFirstChild().getFirstChild();
+           XQueryAST two = (XQueryAST) ast.getNextSibling().getFirstChild().getNextSibling().getFirstChild();
+           XQueryAST three = (XQueryAST) ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild();
+
+           assertEquals("copy-namespaces", one.getText());
+           assertEquals("empty-sequence", two.getText());
+           assertEquals("schema-element", three.getText());
+           assertEquals(XQueryTokenTypes.ATTRIBUTE, one.getType());
+           assertEquals(XQueryTokenTypes.ATTRIBUTE, two.getType());
+           assertEquals(XQueryTokenTypes.ATTRIBUTE, three.getType());
+        }
+    }
+}
+


### PR DESCRIPTION
## Task 5. Resolve an issue with Reserved Names

### Description:

We resolved an issue with Reserved Names (task 5).

To solve this, we needed to add the mentioned keywords to the list of `reservedKeywords`. This ensures that they can also be used as attribute names.

### Reference:

[Issue](https://github.com/eXist-db/exist/issues/2381)

### Type of tests:

We implemented a test to verify the issue has been resolved in `ReservedNamesConflictTest.java`.