### PR TITLE
Task 4. Implement XQuery 3.0 Update Facility

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -238,7 +238,7 @@ moduleDecl throws XPathException
 // === Prolog ===
 
 prolog throws XPathException
-{ boolean inSetters = true; }
+{ boolean inSetters = true; boolean redeclaration = false; }
 :
     (
 		(
@@ -270,6 +270,9 @@ prolog throws XPathException
 			( "declare" "revalidation" )
 			=> revalidationDecl {
 			    inSetters = false;
+			    if(redeclaration)
+                 	throw new XPathException((XQueryAST) returnAST, ErrorCodes.XUST0003, "It is a static error if a Prolog contains more than one revalidation declaration.");
+			    redeclaration = true;
 		    }
         )
 		SEMICOLON!

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -723,6 +723,7 @@ exprSingle throws XPathException
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
+	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
 	;
 
@@ -1307,6 +1308,11 @@ postfixExpr throws XPathException
 		(QUESTION) => lookup
 	)*
 	;
+
+dynamicUpdFunCall throws XPathException
+:
+	"invoke"! "updating"^ primaryExpr ( argumentList )*
+    ;
 
 arrowExpr throws XPathException
 :
@@ -2279,6 +2285,8 @@ reservedKeywords returns [String name]
     "skip" { name = "skip"; }
     |
     "transform" { name = "transform"; }
+    |
+    "invoke" { name = "invoke"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -722,6 +722,7 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	| ( "copy" DOLLAR) => copyModifyExpr
 	| orExpr
 	;
 
@@ -764,6 +765,14 @@ renameExpr throws XPathException
 :
 	"rename" exprSingle "as"! exprSingle
 	;
+
+copyModifyExpr throws XPathException
+:
+	"copy"^ letVarBinding ( COMMA! letVarBinding )*
+	"modify"! exprSingle
+	"return"! exprSingle
+	;
+
 
 // === try/catch ===
 tryCatchExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -266,6 +266,11 @@ prolog throws XPathException
 			// bare keyword updating is valid because of rule CompatibilityAnnotation in the XQUF standard
 			( "declare" (MOD | "updating") )
 			=> annotateDecl { inSetters = false; }
+			|
+			( "declare" "revalidation" )
+			=> revalidationDecl {
+			    inSetters = false;
+		    }
         )
 		SEMICOLON!
     )*
@@ -463,6 +468,11 @@ annotation
         name = "updating";
         #annotation= #(#[ANNOT_DECL, name], #annotation);
     }
+    ;
+
+revalidationDecl throws XPathException
+:
+	"declare"! "revalidation"^ ("strict" | "lax" | "skip")
     ;
 
 eqName returns [String name]
@@ -2236,6 +2246,14 @@ reservedKeywords returns [String name]
 	"array" { name = "array"; }
 	|
 	"updating" { name = "updating"; }
+	|
+	"revalidation" { name = "revalidation"; }
+	|
+    "strict" { name = "strict"; }
+    |
+    "lax" { name = "lax"; }
+    |
+    "skip" { name = "skip"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -723,8 +723,9 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
-	| ( "insert" ) => xqufInsertExpr
-	| ( "delete" ) => xqufDeleteExpr
+	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
+	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
+	| ( "replace" ( "value" | "node" ) ) => xqufReplaceExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -794,6 +795,11 @@ insertExprTargetChoice throws XPathException
 xqufDeleteExpr throws XPathException
 :
 	"delete"^ ( "node"! | "nodes"! ) exprSingle
+	;
+
+xqufReplaceExpr throws XPathException
+:
+	"replace"^ ("value" "of"!)? "node"! exprSingle "with"! exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -726,7 +726,8 @@ exprSingle throws XPathException
 	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
 	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
 	| ( "replace" ( "value" | "node" ) ) => xqufReplaceExpr
-	| ( "copy" DOLLAR) => copyModifyExpr
+	| ( "rename" "node" ) => xqufRenameExpr
+	| ( "copy" DOLLAR ) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
 	;
@@ -800,6 +801,11 @@ xqufDeleteExpr throws XPathException
 xqufReplaceExpr throws XPathException
 :
 	"replace"^ ("value" "of"!)? "node"! exprSingle "with"! exprSingle
+	;
+
+xqufRenameExpr throws XPathException
+:
+	"rename"^ "node"! exprSingle "as"! exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -583,7 +583,7 @@ itemType throws XPathException
 :
 	( "item" LPAREN ) => "item"^ LPAREN! RPAREN!
 	|
-	( "function" LPAREN ) => functionTest
+	( ("function" LPAREN) | ( MOD ) ) => functionTest
 	|
 	( "map" LPAREN ) => mapType
 	|
@@ -618,20 +618,23 @@ atomicType throws XPathException
 
 functionTest throws XPathException
 :
-	( "function" LPAREN STAR RPAREN) => anyFunctionTest
-	|
-	typedFunctionTest
+    annotations
+    (
+	    ( "function" LPAREN STAR RPAREN ) => anyFunctionTest
+	    |
+	    typedFunctionTest
+	)
 	;
 
 anyFunctionTest throws XPathException
 :
-	"function"! LPAREN! s:STAR RPAREN!
+	annotations "function"! LPAREN! s:STAR RPAREN!
 	{ #anyFunctionTest = #(#[FUNCTION_TEST, "anyFunction"], #s); }
 	;
 
 typedFunctionTest throws XPathException
 :
-	"function"! LPAREN! (sequenceType (COMMA! sequenceType)*)? RPAREN! "as" sequenceType
+	annotations "function"! LPAREN! (sequenceType (COMMA! sequenceType)*)? RPAREN! "as" sequenceType
 	{ #typedFunctionTest = #(#[FUNCTION_TEST, "anyFunction"], #typedFunctionTest); }
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -724,6 +724,7 @@ exprSingle throws XPathException
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
 	| ( "insert" ) => xqufInsertExpr
+	| ( "delete" ) => xqufDeleteExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -759,6 +760,16 @@ insertExpr throws XPathException
 	( "into" | "preceding" | "following" ) exprSingle
 	;
 
+deleteExpr throws XPathException
+:
+	"delete" exprSingle
+	;
+
+renameExpr throws XPathException
+:
+	"rename" exprSingle "as"! exprSingle
+	;
+
 xqufInsertExpr throws XPathException
 :
 	"insert"^ ( "node"! | "nodes"! ) exprSingle
@@ -780,14 +791,9 @@ insertExprTargetChoice throws XPathException
 
 ;
 
-deleteExpr throws XPathException
+xqufDeleteExpr throws XPathException
 :
-	"delete" exprSingle
-	;
-
-renameExpr throws XPathException
-:
-	"rename" exprSingle "as"! exprSingle
+	"delete"^ ( "node"! | "nodes"! ) exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -180,6 +180,7 @@ imaginaryTokenDefinitions
 	PRAGMA
 	GTEQ
 	SEQUENCE
+	INSERT_TARGET
 	;
 
 // === XPointer ===
@@ -722,6 +723,7 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	| ( "insert" ) => xqufInsertExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -756,6 +758,27 @@ insertExpr throws XPathException
 	"insert" exprSingle
 	( "into" | "preceding" | "following" ) exprSingle
 	;
+
+xqufInsertExpr throws XPathException
+:
+	"insert"^ ( "node"! | "nodes"! ) exprSingle
+	insertExprTargetChoice exprSingle
+	;
+
+insertExprTargetChoice throws XPathException
+{ String target = null; }
+:
+    (
+        ( ( "as"! ( "first"! { target = "first"; } | "last"! { target = "last"; } )  )? "into"! {
+            if (target == null)
+                target = "into";
+        } )
+        | "after"! { target = "after"; }
+        | "before"! { target = "before"; }
+    )
+    { #insertExprTargetChoice= #(#[INSERT_TARGET, target]); }
+
+;
 
 deleteExpr throws XPathException
 :
@@ -2287,6 +2310,16 @@ reservedKeywords returns [String name]
     "transform" { name = "transform"; }
     |
     "invoke" { name = "invoke"; }
+    |
+    "nodes" { name = "nodes"; }
+    |
+    "first" { name = "first"; }
+    |
+    "last" { name = "last"; }
+    |
+    "after" { name = "after"; }
+    |
+    "before" { name = "before"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -263,7 +263,8 @@ prolog throws XPathException
             ( "declare" "context" "item" )
             => contextItemDeclUp { inSetters = false; }
 			|
-			( "declare" MOD )
+			// bare keyword updating is valid because of rule CompatibilityAnnotation in the XQUF standard
+			( "declare" (MOD | "updating") )
 			=> annotateDecl { inSetters = false; }
         )
 		SEMICOLON!
@@ -456,6 +457,12 @@ annotation
 :
 	MOD! name=eqName! (LPAREN! literal (COMMA! literal)* RPAREN!)?
         { #annotation= #(#[ANNOT_DECL, name], #annotation); }
+
+    | "updating"!
+    {
+        name = "updating";
+        #annotation= #(#[ANNOT_DECL, name], #annotation);
+    }
     ;
 
 eqName returns [String name]
@@ -2224,6 +2231,8 @@ reservedKeywords returns [String name]
 	"map" { name = "map"; }
 	|
 	"array" { name = "array"; }
+	|
+	"updating" { name = "updating"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1030,7 +1030,7 @@ castableExpr throws XPathException
 
 castExpr throws XPathException
 :
-	arrowExpr ( "cast"^ "as"! singleType )?
+	transformWithExpr ( "cast"^ "as"! singleType )?
 	;
 
 comparisonExpr throws XPathException
@@ -1302,6 +1302,17 @@ postfixExpr throws XPathException
 arrowExpr throws XPathException
 :
     unaryExpr ( ARROW_OP^ arrowFunctionSpecifier argumentList )*
+    ;
+
+
+// This is not perfectly adherent to the standard grammar
+// at https://www.w3.org/TR/xquery-31/#prod-xquery31-ArrowExpr
+// but the standard XQuery 3.1 grammar conflicts with the XQuery Update Facility 3.0 grammar
+// https://www.w3.org/TR/xquery-update-30/#prod-xquery30-TransformWithExpr
+// However, the end behavior should be identical
+transformWithExpr throws XPathException
+:
+    arrowExpr ( "transform"^ "with"! LCURLY! ( expr )? RCURLY! )?
     ;
 
 arrowFunctionSpecifier throws XPathException
@@ -2257,6 +2268,8 @@ reservedKeywords returns [String name]
     "lax" { name = "lax"; }
     |
     "skip" { name = "skip"; }
+    |
+    "transform" { name = "transform"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -156,8 +156,36 @@ options {
 		}
 	}
 
+    private static Annotation[] processAnnotations(List annots) {
+            Annotation[] anns = new Annotation[annots.size()];
+
+            //iterate the declare Annotations
+            for(int i = 0; i < anns.length; i++) {
+               List la = (List)annots.get(i);
+
+               //extract the Value for the Annotation
+               LiteralValue[] aValue;
+               if(la.size() > 1) {
+
+                PathExpr aPath = (PathExpr)la.get(1);
+
+                aValue = new LiteralValue[aPath.getSubExpressionCount()];
+                for(int j = 0; j < aValue.length; j++) {
+                    aValue[j] = (LiteralValue)aPath.getExpression(j);
+                }
+               } else {
+                aValue = new LiteralValue[0];
+               }
+
+               Annotation a = new Annotation((QName)la.get(0), aValue, null);
+               anns[i] = a;
+            }
+
+            return anns;
+    	}
+
 	private static void processAnnotations(List annots, FunctionSignature signature) {
-	    Annotation[] anns = new Annotation[annots.size()];
+        Annotation[] anns = new Annotation[annots.size()];
 
         //iterate the declare Annotations
         for(int i = 0; i < anns.length; i++) {
@@ -1066,6 +1094,12 @@ throws XPathException
 			}
 		)
 		|
+		{ List annots = new ArrayList(); }
+        (annotations [annots])?
+		{
+		    Annotation[] anns = processAnnotations(annots);
+		    type.setAnnotations(anns);
+		}
 		#(
 			FUNCTION_TEST { type.setPrimaryType(Type.FUNCTION_REFERENCE); }
 			(

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -497,6 +497,24 @@ throws PermissionDeniedException, EXistException, XPathException
                         { List annots = new ArrayList(); }
                         (annotations [annots]
                         )?
+                        {
+                            for(int i = 0; i < annots.size(); i++)
+                            {
+                            	List la = (List) annots.get(i);
+                                if(la.size() > 0)
+                                {
+                                    for(int a = 0; a < la.size(); a++)
+                                    {
+                                         if(la.get(a).toString().equals("simple") || la.get(a).toString().equals("updating"))
+                                         {
+                                             throw new XPathException(qname, ErrorCodes.XUST0032,
+                                             "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+                                         }
+                                    }
+                                }
+                            }
+
+                        }
 			(
 				#(
 					"as"

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2142,6 +2142,8 @@ throws PermissionDeniedException, EXistException, XPathException
 	step=xqufInsertExpr [path]
 	|
     step=xqufDeleteExpr [path]
+    |
+    step=xqufReplaceExpr [path]
 	|
     step=transformWithExpr [path]
     |
@@ -3823,6 +3825,35 @@ throws XPathException, PermissionDeniedException, EXistException
 			deleteExpr.setASTNode(deleteAST);
 			path.add(deleteExpr);
 			step = deleteExpr;
+		}
+	)
+	;
+
+xqufReplaceExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    replaceAST:"replace"
+		{
+			PathExpr target = new PathExpr(context);
+			PathExpr with = new PathExpr(context);
+			ReplaceExpr.ReplacementType replacementType = ReplaceExpr.ReplacementType.NODE;
+		}
+		(
+		    "value"
+		    {
+		        replacementType = ReplaceExpr.ReplacementType.VALUE;
+		    }
+		)?
+		step=expr [target]
+		step=expr [with]
+		{
+			ReplaceExpr replaceExpr = new ReplaceExpr(context, target, with, replacementType);
+			replaceExpr.setASTNode(replaceAST);
+			path.add(replaceExpr);
+			step = replaceExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -146,7 +146,7 @@ options {
 		String ns = qname.getNamespaceURI();
         if (ns.equals(Namespaces.XPATH_FUNCTIONS_NS)) {
 			String ln = qname.getLocalPart();
-			return ("private".equals(ln) || "public".equals(ln));
+			return ("private".equals(ln) || "public".equals(ln) || "updating".equals(ln) || "simple".equals(ln));
 		} else {
 			return !(ns.equals(Namespaces.XML_NS)
                      || ns.equals(Namespaces.SCHEMA_NS)

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2141,6 +2141,8 @@ throws PermissionDeniedException, EXistException, XPathException
 	|
 	step=xqufInsertExpr [path]
 	|
+    step=xqufDeleteExpr [path]
+	|
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3801,6 +3803,26 @@ throws XPathException, PermissionDeniedException, EXistException
 			insertExpr.setASTNode(insertAST);
 			path.add(insertExpr);
 			step = insertExpr;
+		}
+	)
+	;
+
+xqufDeleteExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    deleteAST:"delete"
+		{
+			PathExpr target = new PathExpr(context);
+		}
+		step=expr [target]
+		{
+			DeleteExpr deleteExpr = new DeleteExpr(context, target);
+			deleteExpr.setASTNode(deleteAST);
+			path.add(deleteExpr);
+			step = deleteExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2139,6 +2139,8 @@ throws PermissionDeniedException, EXistException, XPathException
 	|
 	step=updateExpr [path]
 	|
+	step=xqufInsertExpr [path]
+	|
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3754,6 +3756,51 @@ throws XPathException, PermissionDeniedException, EXistException
 			mod.setASTNode(updateAST);
 			path.add(mod);
 			step = mod;
+		}
+	)
+	;
+
+xqufInsertExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    insertAST:"insert"
+		{
+			PathExpr source = new PathExpr(context);
+			PathExpr target = new PathExpr(context);
+			InsertExpr.Choice choice = null;
+		}
+		step=expr [source]
+		#(
+			it:INSERT_TARGET
+			{
+			    switch (it.getText()) {
+			        case "first":
+			            choice = InsertExpr.Choice.FIRST;
+			            break;
+                    case "last":
+                        choice = InsertExpr.Choice.LAST;
+                        break;
+                    case "into":
+                        choice = InsertExpr.Choice.INTO;
+                        break;
+                    case "before":
+                        choice = InsertExpr.Choice.BEFORE;
+                        break;
+                    case "after":
+                        choice = InsertExpr.Choice.AFTER;
+                        break;
+			    }
+			}
+		)
+		step=expr [target]
+		{
+			InsertExpr insertExpr = new InsertExpr(context, source, target, choice);
+			insertExpr.setASTNode(insertAST);
+			path.add(insertExpr);
+			step = insertExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2138,6 +2138,10 @@ throws PermissionDeniedException, EXistException, XPathException
 	step=numericExpr [path]
 	|
 	step=updateExpr [path]
+	|
+    step=transformWithExpr [path]
+    |
+    step=copyModifyExpr [path]
 	;
 
 /**
@@ -3484,6 +3488,92 @@ throws PermissionDeniedException, EXistException, XPathException
 			}
 		}
 	)
+	;
+
+
+transformWithExpr [PathExpr path]
+returns [Expression step]
+throws PermissionDeniedException, EXistException, XPathException
+{
+	step= null;
+	CopyModifyExpression cpme = new CopyModifyExpression(context);
+	QName virtualVariable = null;
+}:
+	#(
+		tr:"transform"
+		{
+			PathExpr transformExpr = new PathExpr(context);
+		}
+		t:expr [transformExpr]
+		{
+		    try {
+               virtualVariable = QName.parse(staticContext, "virtualCopyModifyName", null);
+            }
+            catch (final IllegalQNameException e) {
+                // this should never happen, since it is a virtual QName
+            }
+
+		    final VariableDeclaration decl = new VariableDeclaration(context, virtualVariable, transformExpr);
+            decl.setASTNode(t);
+
+            cpme.addCopySource("virtualCopyModifyName", decl);
+		}
+		{
+		    PathExpr withExpr = new PathExpr(context);
+		}
+		(
+            expr [withExpr]
+        )?
+        {
+            // see https://www.w3.org/TR/xquery-update-30/#id-transform-with for explanation
+            // in short TransformWith is a shorthand notation for a common Copy Modify Expression
+
+            PathExpr refExpr = new PathExpr(context);
+            refExpr.add(new VariableReference(context, virtualVariable));
+            cpme.setModifyExpr(new OpSimpleMap(context, refExpr, withExpr));
+            cpme.setReturnExpr(refExpr);
+
+            cpme.setASTNode(tr);
+            path.add(cpme);
+            step = cpme;
+        }
+	)
+	;
+
+copyModifyExpr [PathExpr path]
+returns [Expression step]
+throws PermissionDeniedException, EXistException, XPathException
+{
+	step= null;
+	CopyModifyExpression cpme = new CopyModifyExpression(context);
+	PathExpr modify = new PathExpr(context);
+	PathExpr retExpr = new PathExpr(context);
+}:
+	#(
+    	cp:"copy"
+    	(
+    		#(
+    			copyVarName:VARIABLE_BINDING
+    			{
+    				PathExpr inputSequence= new PathExpr(context);
+    			}
+    			step=expr [inputSequence]
+    			{
+    				cpme.addCopySource(copyVarName.getText(), inputSequence);
+    			}
+    		)
+    	)+
+    	step=expr [modify]
+    	step=expr [retExpr]
+    	{
+    	    cpme.setModifyExpr(modify);
+    	    cpme.setReturnExpr(retExpr);
+
+    	    cpme.setASTNode(cp);
+            path.add(cpme);
+            step = cpme;
+    	}
+    )
 	;
 
 typeCastExpr [PathExpr path]

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -658,6 +658,27 @@ throws PermissionDeniedException, EXistException, XPathException
         functionDecl [path]
 		|
 		importDecl [path]
+		|
+		#(
+            "revalidation"
+            (
+                "strict"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.STRICT);
+                }
+                |
+                "lax"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.LAX);
+                }
+                |
+                "skip"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.SKIP);
+                }
+            )
+
+		)
 	)*
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2142,6 +2142,8 @@ throws PermissionDeniedException, EXistException, XPathException
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
+    |
+    step=dynamicUpdFunCall [path]
 	;
 
 /**
@@ -2939,6 +2941,37 @@ throws PermissionDeniedException, EXistException, XPathException
         }
     )
     ;
+
+dynamicUpdFunCall [PathExpr path]
+returns [Expression step]
+throws PermissionDeniedException, EXistException, XPathException
+{
+	step = null;
+	PathExpr primary = new PathExpr(context);
+}
+:
+    #(
+		"updating"
+		{
+			List<Expression> params = new ArrayList<Expression>(5);
+			boolean isPartial = false;
+		}
+        step=primaryExpr [primary]
+		(
+			(
+				{ PathExpr pathExpr = new PathExpr(context); }
+				expr [pathExpr] { params.add(pathExpr); }
+			)
+		)*
+		{
+			DynamicFunctionCall dynCall = new DynamicFunctionCall(context, step, params, isPartial);
+			dynCall.setCategory(Expression.Category.UPDATING);
+			step = dynCall;
+			path.add(step);
+		}
+	)
+;
+
 
 functionCall [PathExpr path]
 returns [Expression step]

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2144,6 +2144,8 @@ throws PermissionDeniedException, EXistException, XPathException
     step=xqufDeleteExpr [path]
     |
     step=xqufReplaceExpr [path]
+    |
+    step=xqufRenameExpr [path]
 	|
     step=transformWithExpr [path]
     |
@@ -3854,6 +3856,28 @@ throws XPathException, PermissionDeniedException, EXistException
 			replaceExpr.setASTNode(replaceAST);
 			path.add(replaceExpr);
 			step = replaceExpr;
+		}
+	)
+	;
+
+xqufRenameExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    renameAST:"rename"
+		{
+			PathExpr target = new PathExpr(context);
+			PathExpr newName = new PathExpr(context);
+		}
+		step=expr [target]
+		step=expr [newName]
+		{
+			RenameExpr renameExpr = new RenameExpr(context, target, newName);
+			renameExpr.setASTNode(renameAST);
+			path.add(renameExpr);
+			step = renameExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/java/org/exist/xquery/CopyModifyExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CopyModifyExpression.java
@@ -42,13 +42,9 @@ public class CopyModifyExpression extends PathExpr {
     protected Expression modifyExpr;
     protected Expression returnExpr;
 
-    public enum Category {
-        UPDATING,
-        SIMPLE
-    }
-
     // see https://www.w3.org/TR/xquery-update-30/#id-copy-modify for details
     public Category getCategory() {
+        // placeholder implementation
         return Category.SIMPLE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/CopyModifyExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CopyModifyExpression.java
@@ -1,0 +1,134 @@
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CopyModifyExpression extends PathExpr {
+
+    public static class CopySource {
+        protected String varName;
+        protected Expression inputSequence;
+
+        public String getVariable() {
+            return this.varName;
+        }
+        public Expression getInputSequence() {
+            return this.inputSequence;
+        }
+
+        public void setVariable(String varName) {
+            this.varName = varName;
+        }
+
+        public void setInputSequence(Expression inputSequence) {
+            this.inputSequence = inputSequence;
+        }
+
+        public CopySource(String name, Expression value) {
+            this.varName = name;
+            this.inputSequence = value;
+        }
+
+        public CopySource() {
+        }
+    }
+
+
+    protected List<CopySource> sources;
+    protected Expression modifyExpr;
+    protected Expression returnExpr;
+
+    public enum Category {
+        UPDATING,
+        SIMPLE
+    }
+
+    // see https://www.w3.org/TR/xquery-update-30/#id-copy-modify for details
+    public Category getCategory() {
+        return Category.SIMPLE;
+    }
+
+    public CopyModifyExpression(XQueryContext context) {
+        super(context);
+        this.sources = new ArrayList<CopySource>();
+    }
+
+    public void addCopySource(String varName, Expression value) {
+        this.sources.add(new CopySource(varName, value));
+    }
+
+    public void setModifyExpr(Expression expr) {
+        this.modifyExpr = expr;
+    }
+
+    public Expression getModifyExpr() {
+        return this.modifyExpr;
+    }
+
+    public void setReturnExpr(Expression expr) {
+        this.returnExpr = expr;
+    }
+
+    public Expression getReturnExpr() {
+        return this.returnExpr;
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(ExpressionDumper dumper) {
+        dumper.display("copy").nl();
+        dumper.startIndent();
+        for(int i = 0; i < sources.size(); i++)
+        {
+            dumper.display("$").display(sources.get(i).varName);
+            dumper.display(" := ");
+            sources.get(i).inputSequence.dump(dumper);
+        }
+        dumper.endIndent();
+        dumper.display("modify").nl();
+        modifyExpr.dump(dumper);
+        dumper.nl().display("return ");
+        dumper.startIndent();
+        returnExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("copy ");
+        for(int i = 0; i < sources.size(); i++)
+        {
+            result.append("$").append(sources.get(i).varName);
+            result.append(sources.get(i).inputSequence.toString());
+            if (sources.size() > 1 && i < sources.size() - 1)
+                result.append(", ");
+            else
+                result.append(" ");
+        }
+        result.append(" ");
+        result.append("modify ");
+        result.append(modifyExpr.toString());
+        result.append(" ");
+        result.append("return ");
+        result.append(returnExpr.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/DeleteExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/DeleteExpr.java
@@ -1,0 +1,41 @@
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+public class DeleteExpr extends ModifyingExpression {
+
+    public DeleteExpr(XQueryContext context, Expression target)
+    {
+        super(context, target);
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException
+    {
+
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException
+    {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    public void dump(ExpressionDumper dumper) {
+        dumper.display("delete").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("delete ");
+        result.append(" ");
+        result.append(targetExpr.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
@@ -34,8 +34,9 @@ public class DynamicFunctionCall extends AbstractExpression {
     private final Expression functionExpr;
     private final List<Expression> arguments;
     private final boolean isPartial;
-    
     private AnalyzeContextInfo cachedContextInfo;
+
+    private Category category = Category.SIMPLE;
 
     public DynamicFunctionCall(final XQueryContext context, final Expression fun, final List<Expression> args, final boolean partial) {
         super(context);
@@ -154,5 +155,15 @@ public class DynamicFunctionCall extends AbstractExpression {
         }
 
         return builder.toString();
+    }
+
+
+    @Override
+    public Category getCategory() {
+        return this.category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -228,6 +228,9 @@ public class ErrorCodes {
             "module has incorrect type");
     public static final ErrorCode FOQM0006 = new W3CErrorCode("FOQM0006", "No suitable XQuery processor available.");
 
+    /* XQuery 3.0 Update Facility https://www.w3.org/TR/xquery-update-30/#id-new-error-codes */
+    public static final ErrorCode XUST0032 = new W3CErrorCode("XUST0032", "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+
     /* eXist specific XQuery and XPath errors
      *
      * Codes have the format [EX][XQ|XP][DY|SE|ST][nnnn]

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -230,6 +230,7 @@ public class ErrorCodes {
 
     /* XQuery 3.0 Update Facility https://www.w3.org/TR/xquery-update-30/#id-new-error-codes */
     public static final ErrorCode XUST0032 = new W3CErrorCode("XUST0032", "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+    public static final ErrorCode XUST0003 = new W3CErrorCode("XUST0003", "It is a static error if a Prolog contains more than one revalidation declaration.");
 
     /* eXist specific XQuery and XPath errors
      *

--- a/exist-core/src/main/java/org/exist/xquery/Expression.java
+++ b/exist-core/src/main/java/org/exist/xquery/Expression.java
@@ -36,6 +36,16 @@ import org.exist.xquery.value.Sequence;
  */
 public interface Expression {
 
+    /**
+     * Updating expressions are a new category of expression introduced by XQuery Update Facility 3.0
+     * An updating expression is an expression that can return a non-empty pending update list
+     * Simple expressions are all expressions that are not updating expressions
+     */
+    enum Category {
+        UPDATING,
+        SIMPLE
+    }
+
     // Flags to be passed to analyze:
     /**
      * Indicates that the query engine will call the expression once for every
@@ -255,4 +265,6 @@ public interface Expression {
     public boolean allowMixedNodesInReturn();
 
     public Expression getParent();
+
+    public default Category getCategory() { return Category.SIMPLE; };
 }

--- a/exist-core/src/main/java/org/exist/xquery/InsertExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/InsertExpr.java
@@ -3,10 +3,8 @@ package org.exist.xquery;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.Type;
 
-public class InsertExpr extends AbstractExpression
-{
+public class InsertExpr extends ModifyingExpression {
     public enum Choice {
         FIRST,
         LAST,
@@ -15,14 +13,12 @@ public class InsertExpr extends AbstractExpression
         BEFORE
     }
 
-    protected final Expression source;
-    protected final Expression target;
+    protected final Expression sourceExpr;
     protected final Choice choice;
 
     public InsertExpr(XQueryContext context, Expression source, Expression target, Choice choice) {
-        super(context);
-        this.source = source;
-        this.target = target;
+        super(context, target);
+        this.sourceExpr = source;
         this.choice = choice;
     }
 
@@ -36,18 +32,6 @@ public class InsertExpr extends AbstractExpression
     }
 
     @Override
-    public int returnsType()
-    {
-        // placeholder implementation
-        return Type.EMPTY;
-    }
-
-    public Category getCategory() {
-        // placeholder implementation
-        return Category.UPDATING;
-    }
-
-    @Override
     public Cardinality getCardinality() {
         return Cardinality.ONE_OR_MORE;
     }
@@ -56,22 +40,31 @@ public class InsertExpr extends AbstractExpression
     public void dump(ExpressionDumper dumper) {
         dumper.display("insert").nl();
         dumper.startIndent();
-        source.dump(dumper);
+        sourceExpr.dump(dumper);
         dumper.endIndent();
         dumper.display(choice).nl();
         dumper.startIndent();
-        target.dump(dumper);
+        targetExpr.dump(dumper);
+        dumper.endIndent();
     }
 
     @Override
     public String toString() {
         final StringBuilder result = new StringBuilder();
         result.append("insert ");
-        result.append(source.toString());
+        result.append(sourceExpr.toString());
         result.append(" ");
         result.append(choice.toString());
         result.append(" ");
-        result.append(target.toString());
+        result.append(targetExpr.toString());
         return result.toString();
+    }
+
+    public Choice getChoice() {
+        return choice;
+    }
+
+    public Expression getSourceExpr() {
+        return sourceExpr;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/InsertExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/InsertExpr.java
@@ -1,0 +1,77 @@
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
+
+public class InsertExpr extends AbstractExpression
+{
+    public enum Choice {
+        FIRST,
+        LAST,
+        INTO,
+        AFTER,
+        BEFORE
+    }
+
+    protected final Expression source;
+    protected final Expression target;
+    protected final Choice choice;
+
+    public InsertExpr(XQueryContext context, Expression source, Expression target, Choice choice) {
+        super(context);
+        this.source = source;
+        this.target = target;
+        this.choice = choice;
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public int returnsType()
+    {
+        // placeholder implementation
+        return Type.EMPTY;
+    }
+
+    public Category getCategory() {
+        // placeholder implementation
+        return Category.UPDATING;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(ExpressionDumper dumper) {
+        dumper.display("insert").nl();
+        dumper.startIndent();
+        source.dump(dumper);
+        dumper.endIndent();
+        dumper.display(choice).nl();
+        dumper.startIndent();
+        target.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("insert ");
+        result.append(source.toString());
+        result.append(" ");
+        result.append(choice.toString());
+        result.append(" ");
+        result.append(target.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/ModifyingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModifyingExpression.java
@@ -1,0 +1,27 @@
+package org.exist.xquery;
+
+import org.exist.xquery.value.Type;
+
+public abstract class ModifyingExpression extends AbstractExpression {
+
+    protected final Expression targetExpr;
+
+    public ModifyingExpression(XQueryContext context, Expression target) {
+        super(context);
+        this.targetExpr = target;
+    }
+
+    @Override
+    public int returnsType() {
+        // placeholder implementation
+        return Type.EMPTY;
+    }
+
+    public Category getCategory() {
+        return Category.UPDATING;
+    }
+
+    public Expression getTargetExpr() {
+        return targetExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/RenameExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/RenameExpr.java
@@ -1,0 +1,53 @@
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+public class RenameExpr extends ModifyingExpression {
+    protected final Expression newNameExpr;
+
+    public RenameExpr(XQueryContext context, Expression target, Expression newName) {
+        super(context, target);
+        this.newNameExpr = newName;
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(ExpressionDumper dumper) {
+        dumper.display("replace").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+        dumper.startIndent();
+        newNameExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("replace ");
+        result.append(targetExpr.toString());
+        result.append(" ");
+        result.append(newNameExpr.toString());
+        return result.toString();
+    }
+
+    public Expression getNewNameExpr() {
+        return newNameExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/ReplaceExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ReplaceExpr.java
@@ -1,0 +1,67 @@
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+public class ReplaceExpr extends ModifyingExpression{
+    public enum ReplacementType {
+        NODE,
+        VALUE
+    }
+
+    protected final Expression withExpr;
+    protected final ReplaceExpr.ReplacementType replacementType;
+
+    public ReplaceExpr(XQueryContext context, Expression target, Expression with, ReplaceExpr.ReplacementType replacementType) {
+        super(context, target);
+        this.withExpr = with;
+        this.replacementType = replacementType;
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(ExpressionDumper dumper) {
+        dumper.display("replace").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+        dumper.display(replacementType).nl();
+        dumper.startIndent();
+        withExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("replace ");
+        result.append(targetExpr.toString());
+        result.append(" ");
+        result.append(replacementType.toString());
+        result.append(" ");
+        result.append(withExpr.toString());
+        return result.toString();
+    }
+
+    public ReplaceExpr.ReplacementType getReplacementType() {
+        return replacementType;
+    }
+
+    public Expression getWithExpr() {
+        return withExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -109,6 +109,7 @@ import static org.exist.Namespaces.XML_NS;
  *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
+
 public class XQueryContext implements BinaryValueManager, Context {
 
     private static final Logger LOG = LogManager.getLogger(XQueryContext.class);
@@ -419,6 +420,8 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     private final Map<QName, DecimalFormat> staticDecimalFormats = new HashMap<>();
     private static final QName UNNAMED_DECIMAL_FORMAT = new QName("__UNNAMED__", Function.BUILTIN_FUNCTION_NS);
+
+    private RevalidationMode revalidationMode = RevalidationMode.LAX;
 
     public XQueryContext() {
         profiler = new Profiler(null);
@@ -3259,6 +3262,22 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         binaryValueInstances.push(binaryValue);
     }
+
+    public enum RevalidationMode {
+        STRICT,
+        LAX,
+        SKIP
+    }
+
+    /**
+     * Revalidation mode controls the process by which type information
+     * is recovered for an updated document
+     */
+    public void setRevalidationMode(final RevalidationMode rev) {
+        this.revalidationMode = rev;
+    }
+
+    public RevalidationMode getRevalidationMode() { return this.revalidationMode; }
 
     /**
      * Cleanup Task which is responsible for relasing the streams

--- a/exist-core/src/main/java/org/exist/xquery/update/Modification.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/Modification.java
@@ -351,4 +351,7 @@ public abstract class Modification extends AbstractExpression
             return node.getParentNode();
         }
     }
+
+    @Override
+    public Category getCategory() { return Category.UPDATING; }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.value;
 
 import org.exist.dom.QName;
+import org.exist.xquery.Annotation;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Document;
@@ -39,6 +40,8 @@ public class SequenceType {
     private int primaryType = Type.ITEM;
     private Cardinality cardinality = Cardinality.EXACTLY_ONE;
     private QName nodeName = null;
+
+    private Annotation[] annotations;
 
     public SequenceType() {
     }
@@ -227,6 +230,13 @@ public class SequenceType {
         } else if (seq.hasMany() && cardinality.atMostOne()) {
             throw new XPathException("Sequence with more than one item is not allowed here");
         }
+    }
+
+    public void setAnnotations(final Annotation[] annotations) {
+        this.annotations = annotations;
+    }
+    public Annotation[] getAnnotations() {
+        return annotations;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -12,6 +12,8 @@ import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
 import org.exist.xquery.parser.XQueryTreeParser;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -127,6 +129,35 @@ public class XQueryUpdate3Test
         }
         catch(XPathException ex) {
             assertEquals(ErrorCodes.XUST0032, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    public void testingForUpdatingFunction() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "%simple function ( * )";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.sequenceType();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            SequenceType type = new SequenceType();
+            treeParser.sequenceType(ast, type);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -252,4 +252,39 @@ public class XQueryUpdate3Test
             }
         }
     }
+
+    @Test
+    public void dynamicUpdatingFunctionCall() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "let $f := fn:put#2\n" +
+                "return invoke updating $f(<newnode/>,\"newnode.xml\")";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(((DebuggableExpression) ((LetExpr)expr.getFirst()).returnExpr).getFirst() instanceof DynamicFunctionCall);
+            DynamicFunctionCall dfc = (DynamicFunctionCall) ((DebuggableExpression) ((LetExpr)expr.getFirst()).returnExpr).getFirst();
+            assertEquals(Expression.Category.UPDATING, dfc.getCategory());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -322,4 +322,38 @@ public class XQueryUpdate3Test
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
         }
     }
+
+    @Test
+    public void deleteExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "delete node fn:doc(\"bib.xml\")/books/book[1]/author[last()]";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof DeleteExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -430,4 +430,40 @@ public class XQueryUpdate3Test
             assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}price * 1.1",((ReplaceExpr) expr.getFirst()).getWithExpr().toString());
         }
     }
+
+    @Test
+    public void renameExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "rename node fn:doc(\"bib.xml\")/books/book[1]/author[1]\n" +
+                        "as \"principal-author\"";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof RenameExpr);
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[1]",((RenameExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("\"principal-author\"",((RenameExpr) expr.getFirst()).getNewNameExpr().toString());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -160,4 +160,34 @@ public class XQueryUpdate3Test
             }
         }
     }
+
+    @Test
+    public void revalidationDeclaration() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "declare revalidation strict;";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.prolog();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.prolog(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -356,4 +356,78 @@ public class XQueryUpdate3Test
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
         }
     }
+
+    @Test
+    public void replaceNodeExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "replace node fn:doc(\"bib.xml\")/books/book[1]/publisher\n" +
+                        "with fn:doc(\"bib.xml\")/books/book[2]/publisher";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof ReplaceExpr);
+            assertEquals(ReplaceExpr.ReplacementType.NODE,((ReplaceExpr) expr.getFirst()).getReplacementType());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}publisher",((ReplaceExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[2]/child::{}publisher",((ReplaceExpr) expr.getFirst()).getWithExpr().toString());
+        }
+    }
+
+    @Test
+    public void replaceValueExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "replace value of node fn:doc(\"bib.xml\")/books/book[1]/price\n" +
+                        "with fn:doc(\"bib.xml\")/books/book[1]/price * 1.1";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof ReplaceExpr);
+            assertEquals(ReplaceExpr.ReplacementType.VALUE,((ReplaceExpr) expr.getFirst()).getReplacementType());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}price",((ReplaceExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}price * 1.1",((ReplaceExpr) expr.getFirst()).getWithExpr().toString());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -287,4 +287,39 @@ public class XQueryUpdate3Test
             assertEquals(Expression.Category.UPDATING, dfc.getCategory());
         }
     }
+
+    @Test
+    public void insertExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "insert node <year>2005</year>\n" +
+                "    after book/publisher";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof InsertExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -190,4 +190,66 @@ public class XQueryUpdate3Test
             }
         }
     }
+
+    @Test
+    public void transformWith() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "$e transform with { $e + 1 }\n";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            Expression ret = treeParser.expr(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+        }
+    }
+
+    @Test
+    public void copyModifyExprTest() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "copy $je := $e\n" +
+                "   modify $je\n" +
+                "   return $je";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -102,4 +102,31 @@ public class XQueryUpdate3Test
             }
         }
     }
+
+    @Test
+    public void simpleAnnotationIsInvalidForVariableDeclaration() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "declare %simple variable $ab := 1;";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.prolog();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.prolog(ast, expr);
+        }
+        catch(XPathException ex) {
+            assertEquals(ErrorCodes.XUST0032, ex.getErrorCode());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -226,7 +226,7 @@ public class XQueryUpdate3Test
     public void copyModifyExprTest() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
     {
         String query = "copy $je := $e\n" +
-                "   modify $je\n" +
+                "   modify delete node $je/salary\n" +
                 "   return $je";
 
         BrokerPool pool = BrokerPool.getInstance();
@@ -245,11 +245,50 @@ public class XQueryUpdate3Test
 
             XQueryTreeParser treeParser = new XQueryTreeParser(context);
             PathExpr expr = new PathExpr(context);
-            treeParser.expr(ast, expr);
+            Expression ret = treeParser.expr(ast, expr);
             if (treeParser.foundErrors()) {
                 fail(treeParser.getErrorMessage());
                 return;
             }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+            assertEquals("$je",((CopyModifyExpression) ret).getReturnExpr().toString());
+        }
+    }
+
+    @Test
+    public void copyModifyExprTestComplexModify() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "copy $newx := $oldx\n" +
+                "   modify (rename node $newx as \"newx\", \n" +
+                "           replace value of node $newx with $newx * 2)\n" +
+                "   return ($oldx, $newx)";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            Expression ret = treeParser.expr(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+            assertEquals("( replace $newx \"newx\", replace $newx VALUE $newx * 2 )",((CopyModifyExpression) ret).getModifyExpr().toString());
+            assertEquals("( $oldx, $newx )",((CopyModifyExpression) ret).getReturnExpr().toString());
         }
     }
 
@@ -320,6 +359,48 @@ public class XQueryUpdate3Test
 
             assertTrue(expr.getFirst() instanceof InsertExpr);
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals(InsertExpr.Choice.AFTER, ((InsertExpr) expr.getFirst()).getChoice());
+        }
+    }
+
+    @Test
+    public void insertExprAsLast() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "insert node $new-police-report\n" +
+                        "   as last into fn:doc(\"insurance.xml\")/policies\n" +
+                        "      /policy[id = $pid]\n" +
+                        "      /driver[license = $license]\n" +
+                        "      /accident[date = $accdate]\n" +
+                        "      /police-reports";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof InsertExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals("$new-police-report", ((InsertExpr) expr.getFirst()).getSourceExpr().toString());
+            assertEquals(InsertExpr.Choice.LAST, ((InsertExpr) expr.getFirst()).getChoice());
         }
     }
 
@@ -328,6 +409,42 @@ public class XQueryUpdate3Test
     {
         String query =
                 "delete node fn:doc(\"bib.xml\")/books/book[1]/author[last()]";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof DeleteExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[last()]", ((DeleteExpr) expr.getFirst()).getTargetExpr().toString());
+        }
+    }
+
+    @Test
+    public void deleteExprComplex() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "delete nodes /email/message\n" +
+                        "     [date > xs:dayTimeDuration(\"P365D\")]";
 
         BrokerPool pool = BrokerPool.getInstance();
         try(final DBBroker broker = pool.getBroker()) {
@@ -464,6 +581,42 @@ public class XQueryUpdate3Test
             assertTrue(expr.getFirst() instanceof RenameExpr);
             assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[1]",((RenameExpr) expr.getFirst()).getTargetExpr().toString());
             assertEquals("\"principal-author\"",((RenameExpr) expr.getFirst()).getNewNameExpr().toString());
+        }
+    }
+
+    @Test
+    public void renameExprWithExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "rename node fn:doc(\"bib.xml\")/books/book[1]/author[1]\n" +
+                        "as $newname";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof RenameExpr);
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[1]",((RenameExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("$newname",((RenameExpr) expr.getFirst()).getNewNameExpr().toString());
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -1,2 +1,105 @@
-package org.exist.xquery;public class XQueryUpdate3Test {
+package org.exist.xquery;
+
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
+import antlr.collections.AST;
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.parser.XQueryAST;
+import org.exist.xquery.parser.XQueryLexer;
+import org.exist.xquery.parser.XQueryParser;
+import org.exist.xquery.parser.XQueryTreeParser;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.*;
+
+public class XQueryUpdate3Test
+{
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void updatingCompatibilityAnnotation() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "xquery version \"3.0\"\n;" +
+                "module namespace t=\"http://exist-db.org/xquery/test/examples\";\n" +
+                "declare updating function" +
+                "   t:upsert($e as element(), \n" +
+                "          $an as xs:QName, \n" +
+                "          $av as xs:anyAtomicType) \n" +
+                "   {\n" +
+                "   let $ea := $e/attribute()[fn:node-name(.) = $an]\n" +
+                "   return\n" +
+                "     $ea\n" +
+                "   };";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
+
+    @Test
+    public void simpleAnnotation() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "xquery version \"3.0\"\n;" +
+                        "module namespace t=\"http://exist-db.org/xquery/test/examples\";\n" +
+                        "declare %simple function" +
+                        "   t:upsert($e as element(), \n" +
+                        "          $an as xs:QName, \n" +
+                        "          $av as xs:anyAtomicType) \n" +
+                        "   {\n" +
+                        "   let $ea := $e/attribute()[fn:node-name(.) = $an]\n" +
+                        "   return\n" +
+                        "     $ea\n" +
+                        "   };";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdate3Test.java
@@ -1,0 +1,2 @@
+package org.exist.xquery;public class XQueryUpdate3Test {
+}


### PR DESCRIPTION
## Task 4. Implement XQuery 3.0 Update Facility

### Description:
We implemented XQUF (XQuery Update Facility) 3.0 (task 4).

We Implemented new or changed declarations (Revalidation declaration/mode, new annotations for function and variable declaration). We have reviewed and completed small syntactic changes to existing expressions. 
We implemented the new expressions:
- Copy Modify expression and Transform With expression
- Dynamic updating function call
- Insert, Delete, Replace and Rename expressions

Notice that the reference mentions 8 new kinds of expressions, but we counted 7. We assume that replace counts as double, since it can replace a node or a value of a node.

To accomplish this task we added several new classes and fields to existing classes.

There were similar constructs for Insert, Delete, Replace and Rename expressions related to the [XQuery Update Extension](https://exist-db.org/exist/apps/doc/update_ext#w3c-rec). Looking at the documentation of that feature and XQUF we observed important semantic differences. I.e., one is designed to update persisting documents and ignores temporary documents, the other one behaves differently). So we created new skeleton Java classes to support these expressions parsed by the ANTLR grammars, instead of re-using the similar classes already present.

### Reference:

[XQuery Update Facility 3.0](https://www.w3.org/TR/xquery-update-30/)

### Type of tests:

We implemented a few tests to verify that the updated parser creates the corresponding AST nodes for the examples.